### PR TITLE
Linter trial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ _CompileInfo
 
 # *nix dev items
 *.swp
+
+# sphinx-build docs
+docs/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# TwinCAT3 items
 _Boot
 _Libraries
 _CompileInfo
@@ -7,3 +8,6 @@ _CompileInfo
 *.tpy
 *.bak
 *.~u
+
+# *nix dev items
+*.swp

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,14 +10,18 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
+repo_slug = os.environ.get("TRAVIS_REPO_SLUG") 
+if repo_slug is not None:
+    project = repo_slug
+else:
+    project = os.environ.get("PROJECT_NAME", "Set 'PROEJECT_NAME'")
 
-project = 'PLC_Project'
 copyright = '2019, SLAC National Accelerator Laboratory'
 author = 'SLAC National Accelerator Laboratory'
 
@@ -39,6 +43,10 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+
+rst_epilog = """
+.. |my_conf_val| replace:: {project}
+""".format(project=project)
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,8 +45,8 @@ exclude_patterns = []
 
 
 rst_epilog = """
-.. |my_conf_val| replace:: {project}
-""".format(project=project)
+.. |project_name| replace:: {project_name}
+""".format(project_name=project)
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ repo_slug = os.environ.get("TRAVIS_REPO_SLUG")
 if repo_slug is not None:
     project = repo_slug
 else:
-    project = os.environ.get("PROJECT_NAME", "Set 'PROEJECT_NAME'")
+    project = os.environ.get("PROJECT_NAME", os.path.split(os.path.abspath('../../'))[-1])
 
 copyright = '2019, SLAC National Accelerator Laboratory'
 author = 'SLAC National Accelerator Laboratory'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to |my_conf_val|'s documentation!
+Welcome to |project_name|'s documentation!
 =========================================
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to PLC_Project's documentation!
-=======================================
+Welcome to |my_conf_val|'s documentation!
+=========================================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Python variables set in the `conf.py` (and hence by environment variables) can be interpreted in sphinx rst docs using `rst_epilog`. 

I'm pretty sure this doesn't work for md files. 
